### PR TITLE
Add TAP subreddit to external resources

### DIFF
--- a/index.md
+++ b/index.md
@@ -49,6 +49,7 @@ TODO review needed
 ## External Resources
 
 -    [Wikipedia article on TAP](http://en.wikipedia.org/wiki/Test_Anything_Protocol)
+-    [The TAP subreddit](http://www.reddit.com/r/testanythingprotocol)
 
 {% comment %}
  TODO review needed


### PR DESCRIPTION
It seems decently maintained by [/u/kinow](http://www.reddit.com/user/kinow) and seems like it would be a nice place to add mixed TAP-related content (articles, projects, news headlines maybe, etc) with neither the process on testanything.org nor the implied “official” endorsement.