### PR TITLE
Overhaul the Ada producer section.

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -53,6 +53,11 @@ ul li {
   margin-left: 1.55em;
 }
 
+blockquote {
+  background-color: #e9e9e9;
+  padding: 0.15em 2em;
+}
+
 div.highlight {
   background-color: #eee;
   border: 1px solid #ccc;

--- a/producers.md
+++ b/producers.md
@@ -11,7 +11,14 @@ Systems which output TAP.
 
 ## Ada
 
--    [Ahven](http://ahven.stronglytyped.org/) unit test library for Ada produces TAP 12 output.
+> Ada is a modern programming language designed for large,
+> long-lived applications – and embedded systems in particular –
+> where safety and security are essential.
+>
+> *From [Ada Information Clearinghouse](http://www.adaic.org/)*
+
+**[Ahven](http://ahven.stronglytyped.org/)** is a unit test library
+for Ada which produces TAP 12 output.
 
 ## Arc (Lisp Dialect)
 


### PR DESCRIPTION
I'd like to take on the task of providing an editorial eye to each language on the producers page with the hope of greatly improving the consistency of the page. Ada is first and a straight forward example of what I'm considering. The structure I have in mind is:

```
Language name

> Blockquote one or two sentence description from the language's primary website.
>
> From <primary website link>

A sentence including the link to the "Testing with Language" page, if it exists.

One paragraph per tool with some reformatting and the addition of actual prose.
The paragraph would attempt to capture all the existing information.
```

My goal is to provide 1 PR for each language until the entire page is done. I would tackle the consumers page after that.