### PR TITLE
Update the Haskell producers section.

### DIFF
--- a/producers.md
+++ b/producers.md
@@ -176,8 +176,17 @@ for `testing/quick.Check` tests.
 <a id="haskell"></a>
 ## Haskell
 
-### TAP Module
--    [HaskellTapModule](http://testanything.org/wiki/index.php/HaskellTapModule)
+> Haskell is an advanced purely-functional programming language.
+>
+> *From [haskell.org](https://www.haskell.org/)*
+
+**[TAP](https://github.com/epsilonhalbe/TAP)** is a TAP producer
+that implements most of the
+[Test::More](http://perldoc.perl.org/Test/More.html) API.
+
+**[tasty-tap](https://github.com/michaelxavier/tasty-tap)** is a TAP producer
+used with the [Tasty](http://documentup.com/feuerbach/tasty) Haskell
+test framework.
 
 <a id="java"></a>
 ## Java


### PR DESCRIPTION
Notes for this section:

* The old link was broken but I found where the code is hosted on GitHub.
* In the process of searching for "haskell tap," I found the tasty-tap project which had more Google juice than the TAP project. Taking that as a sign of its popularity, I added it to the list.