### PR TITLE
Update services producers section.

### DIFF
--- a/consumers.md
+++ b/consumers.md
@@ -30,6 +30,8 @@ Things that can take TAP as an input and do something useful with it.
 -    [node-tap](https://www.npmjs.com/package/tap)
 -    [TAP parser](https://www.npmjs.com/package/tap-parser)
 -    [tape](https://www.npmjs.com/package/tape)
+-    [Testling](https://ci.testling.com/guide/local_tests) consumes browser
+     test output for any browser test suite that outputs TAP to `console.log`.
 
 ## C
 

--- a/consumers.md
+++ b/consumers.md
@@ -41,6 +41,8 @@ Things that can take TAP as an input and do something useful with it.
 -    [Jenkins TAP Plugin](https://wiki.jenkins-ci.org/display/JENKINS/TAP+Plugin)
 -    [Desktop notifications](https://github.com/ryandoyle/shouldertap)
 -    Automake 1.13+ can [run TAP tests](https://www.gnu.org/software/automake/manual/html_node/Using-the-TAP-test-protocol.html#Using-the-TAP-test-protocol) for `make check`, via `tap-driver.sh`.
+-   [Kyua](https://github.com/jmmv/kyua) Testing framework for infrastructure software.
+
 
 ## Universal desirable behaviors
 

--- a/producers.md
+++ b/producers.md
@@ -38,6 +38,9 @@ Languages:
 and
 [TypeScript](#typescript).
 
+Some test frameworks exist with
+[TAP producers that are not language specific](#frameworks).
+
 <a id="ada"></a>
 ## Ada
 
@@ -485,52 +488,18 @@ procedural extension for SQL.
 
 -    [TypeSpec](https://github.com/Steve-Fenton/TypeSpec) - TypeSpec is a BDD framework for TypeScript with a built-in TapReporter class for TAP compliant output.
 
-## Test and developer tools
+<a id="frameworks"></a>
+## Test frameworks
 
-### Automake
-Programming tool that reads data about a project and outputs
-a pattern for a portable makefile which a configure script
-can fill for use by the make program, used in compiling software.
+Some test frameworks solve problems that are not specific to a programming
+language. These frameworks might be used for infrastructure or other kinds
+of high level testing.
 
--   [automake](http://www.gnu.org/software/automake/manual/html_node/Using-the-TAP-test-protocol.html#Using-the-TAP-test-protocol)
+**[autotest](http://autotest.github.io/)** is a framework for fully automated
+testing with the ability to produce TAP reports.
 
-### Hudson
-Extensible Continuous Integration Server.
-
--   [Hudson](http://hudson-ci.org/)
-
-### Jenkins
-Extendable open source continuous integration server.
-
--	[Jenkins](https://wiki.jenkins-ci.org/display/JENKINS/TAP+Plugin)
-
-### Kyua
-Testing framework for infrastructure software.
-
--   [Kyua](https://github.com/jmmv/kyua)
-
-### Tapper
-Test infrastructure.
-
--   [Tapper](http://tapper.github.io/Tapper/)
-
-### Xperior
-Testing tool.
-
-- [Xperior](https://github.com/Xyratex/xperior)
-
-### Autotest
-Autotest is a framework for fully automated testing.
-
--   [autotest](http://autotest.github.io/)
-
-## Web services
-
-### Testling CI
-Hosted service that runs your test suite in many different browsers every time
-you push to GitHub. It can run any test suite so long as it writes TAP to the browser console.
-
--   [Testling](https://ci.testling.com/guide/local_tests)
+**[Xperior](https://github.com/Xyratex/xperior)** is a system for testing
+distributed filesystems. Xperior can output TAP test results.
 
 ### Non Proliferation
 


### PR DESCRIPTION
Notes for this section:

* At the end of this cleanup, the only remaining producers were test frameworks so updated the prose to reflect that.
* Kyua is actually a TAP consumer so I moved it to the consumers section (which I will clean up at a later date).
* Automake is only a consumer and it is already documented on the consumers page so I removed it.
* Hudson does not handle TAP and the plugin that does is actually the TAP Plugin for Jenkins (which explicitly no longer supports Hudson bugs). I removed Hudson.
* The Jenkins TAP plugin is a consumer and is already documented on that page so I removed it.
* Tapper is a consumer that is documented on the consumer page so I removed it.
* Testling still has a website, but the service is dead.
* autotest and Xperior are the remaining valid test producers for this section.