### PR TITLE
Change Main Page to Home.

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Main Page
+title: Home
 ---
 
 # Test Anything Protocol


### PR DESCRIPTION
I think it's time to drop the MediaWiki heritage. :smile:

The internal link in the navigation refers to the index page as "Home." I think that is a great name and should be the name used in the page title too to add consistency across the site.