### PR TITLE
Move the nonproliferation treaty to the TAP history.

### DIFF
--- a/consumers.md
+++ b/consumers.md
@@ -52,7 +52,3 @@ Things that can take TAP as an input and do something useful with it.
 -    Should be forward compatible.
      -    Ignore unknown directives
      -    Ignore any unparsable lines
-
-### Non Proliferation
-
-TAP producer authors should be aware of (and hopefully sign) the [TAP Namespace Nonproliferation Treaty](/namespace-nonproliferation-treaty.html)

--- a/history.md
+++ b/history.md
@@ -6,6 +6,17 @@ title: TAP History
 # TAP History
 Andy Lester thought that the thing we now know as TAP needed a name. (See [How TAP was named](/How_TAP_was_named.html)) The name is relatively recent but the protocol has been around since 1988.
 
+## TAP Namespace Nonproliferation Treaty
+
+TAP has roots from the Perl programming language. Due to conficting namespaces
+in that language, many Perl TAP authors signed a "nonproliferation treaty"
+with the intent to reduce namespace conflicts.
+
+The vast range of programming languages makes the treaty difficult to
+enforce across the TAP ecosystem. The
+[original treaty page](/namespace-nonproliferation-treaty.html)
+is included on this history page for posterity.
+
 ## Historical Versions
 
 Pulling apart the historical revisions of TAP is difficult both because there was no standard and because t/TEST in the perl core and Test::Harness parse slightly different dialects of TAP. Here's the best we can piece together right now. This information comes from Sam Villan's historical Perl GIT repository.

--- a/producers.md
+++ b/producers.md
@@ -531,7 +531,3 @@ Hosted service that runs your test suite in many different browsers every time
 you push to GitHub. It can run any test suite so long as it writes TAP to the browser console.
 
 -   [Testling](https://ci.testling.com/guide/local_tests)
-
-### Non Proliferation
-
-TAP producer authors should be aware of (and hopefully sign) the [TAP Namespace Nonproliferation Treaty](/namespace-nonproliferation-treaty.html)


### PR DESCRIPTION
This should help reduce confusion while respecting that the Perl community may still abide by this treaty.

Fixes #59