### PR TITLE
Fix links to CPAN modules

### DIFF
--- a/consumers.md
+++ b/consumers.md
@@ -9,9 +9,9 @@ Things that can take TAP as an input and do something useful with it.
 
 ## Perl
 
--    [TAP::Parser](http://search.cpan.org/~markwkm/Test-Parser-1.9/lib/Test/Parser.pm)
--    [Test::Harness](http://search.cpan.org/~leont/Test-Harness-3.30/lib/Test/Harness.pm)
--    [Test::Run](http://search.cpan.org/~shlomif/Test-Run-0.0302/lib/Test/Run.pm)
+-    [TAP::Parser](http://search.cpan.org/dist/Test-Harness/lib/TAP/Parser.pm)
+-    [Test::Harness](http://search.cpan.org/dist/Test-Harness/lib/Test/Harness.pm)
+-    [Test::Run](http://search.cpan.org/dist/Test-Run/lib/Test/Run.pm)
 -    [Smolder project background](http://sourceforge.net/projects/smolder/)
 -    [TapTinder](http://dev.taptinder.org/wiki/TapTinder)
 -    [metatap](http://search.cpan.org/search?query=metatap)

--- a/history.md
+++ b/history.md
@@ -114,9 +114,9 @@ Added TODO directive.
 ### Version 12 (Current version)
 Allowed header at end.
 
-Implemented in [Test::Harness](http://search.cpan.org/~leont/Test-Harness-3.30/) 1.21.
+Implemented in [Test::Harness](http://search.cpan.org/dist/Test-Harness/) 1.21.
 
 ### Version 13
 Understands TAP version syntax.
 
-Implemented in [TAP::Parser](http://search.cpan.org/~markwkm/Test-Parser-1.9/) 0.52.
+Implemented in [TAP::Parser](http://search.cpan.org/dist/Test-Harness/lib/TAP/Parser.pm) 0.52.

--- a/testing-with-tap/php.md
+++ b/testing-with-tap/php.md
@@ -8,6 +8,6 @@ title: Testing with PHP
 
 ## Links
 
--    [Using Test::Harness](http://search.cpan.org/~petdance/Test-Harness-2.64/lib/Test/Harness/TAP.pod#PHP)
+-    [Using Test::Harness](https://github.com/Perl-Toolchain-Gang/Test-Harness/blob/master/reference/Test-Harness-2.64/lib/Test/Harness/TAP.pod#php)
 -    [TAP based PHP testing presentations from ApacheCon and OSCon](http://www.modperlcookbook.org/~geoff/)
 -    [Test::Simple &amp; Test::More for PHP](http://code.google.com/p/test-more-php/)


### PR DESCRIPTION
This changeset fixes some broken links and updates CPAN URLs to use `/dist/` instead of a fixed author/version path which can change over time.

Hope this helps,
-Evan