### PR TITLE
Add CTTAP to list of Erlang TAP producers

### DIFF
--- a/producers.md
+++ b/producers.md
@@ -147,6 +147,11 @@ modules that provide a TAP testing client library. These modules are not
 meant to compete with eunit, but to offer a more general testing facility
 that isn't provided by eunit.
 
+**[CTTAP](http://github.com/Stratus3D/cttap)** is Common Test hook that 
+generates TAP output for existing Common Test test suites. CTTAP provides
+a simple way to generate TAP output without having to modify existing
+test code.
+
 <a id="fish"></a>
 ## Fish
 

--- a/producers.md
+++ b/producers.md
@@ -142,15 +142,15 @@ It is available via [Quicklisp](http://www.quicklisp.org/).
 >
 > *From [erlang.org](http://www.erlang.org/)*
 
-**[etap](http://github.com/ngerakines/etap)** is a collection of Erlang
-modules that provide a TAP testing client library. These modules are not
-meant to compete with eunit, but to offer a more general testing facility
-that isn't provided by eunit.
-
-**[CTTAP](http://github.com/Stratus3D/cttap)** is Common Test hook that 
+**[CTTAP](https://github.com/Stratus3D/cttap)** is a Common Test hook that 
 generates TAP output for existing Common Test test suites. CTTAP provides
 a simple way to generate TAP output without having to modify existing
 test code.
+
+**[etap](https://github.com/ngerakines/etap)** is a collection of Erlang
+modules that provide a TAP testing client library. These modules are not
+meant to compete with eunit, but to offer a more general testing facility
+that isn't provided by eunit.
 
 <a id="fish"></a>
 ## Fish


### PR DESCRIPTION
CTTAP is a new TAP producer that integrates with Erlang's existing testing framework (Common Test).