### PR TITLE
Switch to kramdown

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,5 +3,8 @@
 # and regenerated automatifcally by GitHub
 
 name: TestAnything.org
-markdown: redcarpet
+markdown: kramdown
 highlighter: rouge
+kramdown:
+  input: GFM
+  hard_wrap: false

--- a/css/main.css
+++ b/css/main.css
@@ -53,20 +53,29 @@ ul li {
   margin-left: 1.55em;
 }
 
-blockquote {
-  background-color: #e9e9e9;
-  padding: 0.15em 2em;
+pre {
+  margin: 0.5em 0;
 }
 
-div.highlight {
-  background-color: #eee;
+/* code blocks */
+div.highlighter-rouge, blockquote {
+  background-color: #f9f9f9;
   border: 1px solid #ccc;
-  padding: 1em;
+  padding: 0.5em 1.5em;
   border-radius: 3px;
-  margin-bottom: 10px;
+  margin: 0.5em 0em 1.5em;
 }
 
-div.highlight pre {
+/* inline code highlights */
+code.highlighter-rouge {
+  color: #666;
+  background-color: #f9f9f9;
+  border: 1px solid #ccc;
+  padding: 0.5em;
+  border-radius: 3px;
+}
+
+.highlight {
   overflow: auto
 }
 

--- a/css/syntax.css
+++ b/css/syntax.css
@@ -1,4 +1,3 @@
-.highlight  { background: #ffffff; }
 .highlight .c { color: #999988; font-style: italic } /* Comment */
 .highlight .err { color: #a61717; background-color: #e3d2d2 } /* Error */
 .highlight .k { font-weight: bold } /* Keyword */

--- a/history.md
+++ b/history.md
@@ -16,9 +16,9 @@ TAP as understood by Perl 1.0's t/TEST. It understands the basic 1..M header, "o
 This is implemented by t/TEST as part of Perl 1.
 
 ```
- commit 840163baa12f7970131f7841c479bccf5be40ba9
- Author: Larry Wall <lwall@jpl-devvax.jpl.nasa.gov>
- Date:   Sat Jan 30 23:00:00 1988 +0000
+commit 840163baa12f7970131f7841c479bccf5be40ba9
+Author: Larry Wall <lwall@jpl-devvax.jpl.nasa.gov>
+Date:   Sat Jan 30 23:00:00 1988 +0000
 ```
 
 ### Version 2
@@ -28,87 +28,96 @@ Checks the wait/exit status of each test.
 Implemented by Test::Harness in Perl 5.002beta3
 
 ```
- commit 4bce96efdcaa480e392138e10166c92c5fc5f22c
- Author: Perl 5 Porters <perl5-porters@africa.nicoh.com>
- Date:   Fri Feb 2 18:52:27 1996 -0800
+commit 4bce96efdcaa480e392138e10166c92c5fc5f22c
+Author: Perl 5 Porters <perl5-porters@africa.nicoh.com>
+Date:   Fri Feb 2 18:52:27 1996 -0800
 ```
 
 ### Version 3
 
 Comment lines beginning with # are ignored.
+
 ```
- Implemented by Test::Harness in Perl 5.002beta3
- commit 4bce96efdcaa480e392138e10166c92c5fc5f22c
- Author: Perl 5 Porters <perl5-porters@africa.nicoh.com>
- Date:   Fri Feb 2 18:52:27 1996 -0800
+Implemented by Test::Harness in Perl 5.002beta3
+commit 4bce96efdcaa480e392138e10166c92c5fc5f22c
+Author: Perl 5 Porters <perl5-porters@africa.nicoh.com>
+Date:   Fri Feb 2 18:52:27 1996 -0800
 ```
 
 ### Version 4
 Adds the "1..0" header for skipping the entire test. Previously it was considered a passing test.
 
 This is first implemented by t/TEST as part of Perl 5.003_01 followed ten minutes later by Test::Harness.
+
 ```
- commit 845b835a0bd51ac2f83e2e81f4088986d97114ff
- Author: Perl 5 Porters <perl5-porters@africa.nicoh.com>
- Date:   Mon Jul 8 23:11:22 1996 +0000
+commit 845b835a0bd51ac2f83e2e81f4088986d97114ff
+Author: Perl 5 Porters <perl5-porters@africa.nicoh.com>
+Date:   Mon Jul 8 23:11:22 1996 +0000
 ```
 
 ### Version 5
 All non-TAP lines are ignored.
 Implemented by Test::Harness in Perl 5.003_01.
+
 ```
- commit ae85fcb6e790acc2343e92002216642e766aa196
- Author: Perl 5 Porters <perl5-porters@africa.nicoh.com>
- Date:   Mon Jul 8 23:22:00 1996 +0000
+commit ae85fcb6e790acc2343e92002216642e766aa196
+Author: Perl 5 Porters <perl5-porters@africa.nicoh.com>
+Date:   Mon Jul 8 23:22:00 1996 +0000
 ```
 
 ### Version 6
 Support for the skip directive.
 Added in Test::Harness and allow (but ignored) in t/TEST in Perl 5.004_55.
+
 ```
-   Change 318: Output skipped test information in test suite:
-               Subject: 5.004_55: Making test harness platform_aware
-               Date: Wed, 26 Nov 1997 17:16:55 -0500 (EST)
-               Date: Wed, 26 Nov 1997 17:16:55 -0500 (EST)
+Change 318: Output skipped test information in test suite:
+            Subject: 5.004_55: Making test harness platform_aware
+            Date: Wed, 26 Nov 1997 17:16:55 -0500 (EST)
+            Date: Wed, 26 Nov 1997 17:16:55 -0500 (EST)
 ```
 
 ### Version 7
 In-header "todo" syntax added to Test::Harness in Perl 5.004_59.
+
 ```
-   Change 539: Subject: [PATCH 5.004_59] allow the Test::Harness to grok TODO-type tests docs
-       Date: Sat, 14 Feb 1998 17:58:01 -0500
-       From: Joshua Pritikin <pritikin@mindspring.com>
+Change 539: Subject: [PATCH 5.004_59] allow the Test::Harness to grok TODO-type tests docs
+    Date: Sat, 14 Feb 1998 17:58:01 -0500
+    From: Joshua Pritikin <pritikin@mindspring.com>
 ```
 
 ### Version 8
 A reason is added to the skip directive.
 Added in Test::Harness in Perl 5.005_53.
+
 ```
-   Change 3389: From: Ilya Zakharevich <ilya@math.ohio-state.edu>
-               Date: Mon, 10 May 1999 02:07:01 -0400 (EDT)
-               Message-Id: <199905100607.CAA26045@monk.mps.ohio-state.edu>
-               Subject: [PATCH 5.005_53] Explanations by Test::Harness
+Change 3389: From: Ilya Zakharevich <ilya@math.ohio-state.edu>
+            Date: Mon, 10 May 1999 02:07:01 -0400 (EDT)
+            Message-Id: <199905100607.CAA26045@monk.mps.ohio-state.edu>
+            Subject: [PATCH 5.005_53] Explanations by Test::Harness
 ```
 
 ### Version 9
 A reason is added to the skip all header.
+
 ```
-   Change 3399: more testsuite smarts (many of them courtesy Ilya)
+Change 3399: more testsuite smarts (many of them courtesy Ilya)
 ```
 
 ### Version 10
 Added "Bail Out!"
+
 ```
-   Change 8028: Introduce macros for UTF8 decoding.
+Change 8028: Introduce macros for UTF8 decoding.
 ```
 
 ### Version 11
 Added TODO directive.
+
 ```
-   Change 8824: Subject: [PATCH t/TEST lib/Test/Harness.pm] Adding todo tests
-       From: schwern@pobox.com
-       Date: Sun, 18 Feb 2001 01:48:50 -0500
-       Message-ID: <20010218014850.C19957@magnonel.guild.net>
+Change 8824: Subject: [PATCH t/TEST lib/Test/Harness.pm] Adding todo tests
+    From: schwern@pobox.com
+    Date: Sun, 18 Feb 2001 01:48:50 -0500
+    Message-ID: <20010218014850.C19957@magnonel.guild.net>
 ```
 
 ### Version 12 (Current version)

--- a/index.md
+++ b/index.md
@@ -10,11 +10,11 @@ TAP, the Test Anything Protocol, is a simple text-based interface between testin
 Here's what a TAP test stream looks like:
 
 ```
- 1..4
- ok 1 - Input file opened
- not ok 2 - First line of the input valid
- ok 3 - Read the rest of the file
- not ok 4 - Summarized correctly # TODO Not written yet
+1..4
+ok 1 - Input file opened
+not ok 2 - First line of the input valid
+ok 3 - Read the rest of the file
+not ok 4 - Summarized correctly # TODO Not written yet
 ```
 
 ## Testing with TAP

--- a/producers.md
+++ b/producers.md
@@ -42,6 +42,7 @@ Some test frameworks exist with
 [TAP producers that are not language specific](#frameworks).
 
 <a id="ada"></a>
+
 ## Ada
 
 > Ada is a modern programming language designed for large,
@@ -54,6 +55,7 @@ Some test frameworks exist with
 for Ada which produces TAP 12 output.
 
 <a id="c"></a>
+
 ## C
 
 > C is an imperative (procedural) language. It was designed to be compiled
@@ -79,6 +81,7 @@ producer for C. This library is different from the MyTAP producer for MySQL.
 See [SQL](#sql).
 
 <a id="cplusplus"></a>
+
 ## C++
 
 > C++ is a general-purpose programming language with a bias towards
@@ -102,6 +105,7 @@ embedded within `libperl++`. It is a mostly complete port of
 that removes the build time dependency to [Boost](http://www.boost.org/).
 
 <a id="csharp"></a>
+
 ## C&#35;
 
 > C# is a multi-paradigm programming language encompassing strong typing,
@@ -115,6 +119,7 @@ that removes the build time dependency to [Boost](http://www.boost.org/).
 is therefore quite different from tools like NUnit.
 
 <a id="common-lisp"></a>
+
 ## Common Lisp
 
 > Common Lisp is the modern, multi-paradigm, high-performance, compiled,
@@ -135,6 +140,7 @@ Currently, it supports TAP version 12 and xUnit style output.
 It is available via [Quicklisp](http://www.quicklisp.org/).
 
 <a id="erlang"></a>
+
 ## Erlang
 
 > Erlang is a programming language used to build massively scalable soft
@@ -153,6 +159,7 @@ meant to compete with eunit, but to offer a more general testing facility
 that isn't provided by eunit.
 
 <a id="fish"></a>
+
 ## Fish
 
 > fish is a smart and user-friendly command line
@@ -164,6 +171,7 @@ shell for OS X, Linux, and the rest of the family.
 and test harness for fish.
 
 <a id="forth"></a>
+
 ## Forth
 
 > Forth is a computer language originally designed for embedded and
@@ -177,6 +185,7 @@ Check out the [Testing with Forth](/testing-with-tap/forth.html) guide.
 for Forth at an alpha level readiness.
 
 <a id="go"></a>
+
 ## Go
 
 > Go is an open source programming language that makes it easy to build
@@ -188,6 +197,7 @@ for Forth at an alpha level readiness.
 for `testing/quick.Check` tests.
 
 <a id="haskell"></a>
+
 ## Haskell
 
 > Haskell is an advanced purely-functional programming language.
@@ -203,6 +213,7 @@ used with the [Tasty](http://documentup.com/feuerbach/tasty) Haskell
 test framework.
 
 <a id="java"></a>
+
 ## Java
 
 > Java is a general-purpose computer programming language that is concurrent,
@@ -220,6 +231,7 @@ is integrated at the core of other Java projects like the
 [Jenkins TAP Plugin](https://wiki.jenkins-ci.org/display/JENKINS/TAP+Plugin).
 
 <a id="javascript"></a>
+
 ## JavaScript
 
 > JavaScript is a prototype-based, multi-paradigm, dynamic scripting language,
@@ -258,6 +270,7 @@ JavaScript test framework.
 [node]: https://nodejs.org/en/
 
 <a id="limbo"></a>
+
 ## Limbo (OS Inferno)
 
 > Limbo is the application programming language for Inferno.
@@ -271,6 +284,7 @@ JavaScript test framework.
 is a TAP producer that supports version 12.
 
 <a id="lua"></a>
+
 ## Lua
 
 > Lua is a powerful, fast, lightweight, embeddable scripting language.
@@ -285,6 +299,7 @@ a port of the [Test::More](http://perldoc.perl.org/Test/More.html) framework
 to Lua.
 
 <a id="matlab"></a>
+
 ## MATLAB
 
 > MATLAB is a high-level language for numerical computation, visualization,
@@ -298,6 +313,7 @@ is a plugin for the
 framework that produces output in the TAP version 12 format.
 
 <a id="ocaml"></a>
+
 ## OCaml
 
 > OCaml is an industrial strength programming language supporting functional,
@@ -309,6 +325,7 @@ framework that produces output in the TAP version 12 format.
 unit testing framework based on Perl's very successful Test::\* modules.
 
 <a id="pascal"></a>
+
 ## Pascal
 
 > Pascal is a historically influential imperative and procedural
@@ -323,6 +340,7 @@ is a very easy-to-use, but powerful unit testing suite for Pascal
 (FreePascal, Turbo Pascal, et al), conforming to the TAP specification.
 
 <a id="perl"></a>
+
 ## Perl
 
 > Perl is a general-purpose programming language originally developed for
@@ -348,6 +366,7 @@ There are more ambitious Perl modules out there, such as
 [Test::Unit](http://search.cpan.org/perldoc?Test%3A%3AUnit).
 
 <a id="php"></a>
+
 ## PHP
 
 > PHP (recursive acronym for PHP: Hypertext Preprocessor) is a widely-used
@@ -377,6 +396,7 @@ PHP testing library based on
 [Test::More](http://perldoc.perl.org/Test/More.html).
 
 <a id="prolog"></a>
+
 ## Prolog
 
 > Prolog is a general purpose logic programming language that
@@ -391,6 +411,7 @@ written for [SWI-Prolog](http://www.swi-prolog.org/), but may work with
 other Prologs.
 
 <a id="python"></a>
+
 ## Python
 
 > Python is an easy to learn, powerful programming language. It has efficient
@@ -417,6 +438,7 @@ and plugins that output TAP for
 [pytest](http://pytest.org/latest/).
 
 <a id="ruby"></a>
+
 ## Ruby
 
 > Ruby is a dynamic, open source programming language with a focus on
@@ -433,6 +455,7 @@ configurable tool for writing clean and consistent
 [SCSS](http://sass-lang.com) that supports TAP output.
 
 <a id="shell"></a>
+
 ## Shell
 
 > A shell script is a computer program designed to be run by the Unix shell,
@@ -461,6 +484,7 @@ Since all tests output TAP, they can be run with any TAP harness.
 turns bash scripts into TAP test scripts.
 
 <a id="sql"></a>
+
 ## SQL
 
 > SQL (Structured Query Language) is a special-purpose programming language
@@ -487,6 +511,7 @@ is a script for testing with Oracle's
 procedural extension for SQL.
 
 <a id="typescript"></a>
+
 ## TypeScript
 
 > TypeScript is a free and open source programming language developed and
@@ -498,6 +523,7 @@ procedural extension for SQL.
 for TypeScript with a built-in TapReporter class for TAP compliant output.
 
 <a id="frameworks"></a>
+
 ## Test frameworks
 
 Some test frameworks solve problems that are not specific to a programming

--- a/producers.md
+++ b/producers.md
@@ -41,9 +41,7 @@ and
 Some test frameworks exist with
 [TAP producers that are not language specific](#frameworks).
 
-<a id="ada"></a>
-
-## Ada
+## [Ada](#ada) <a id="ada"></a>
 
 > Ada is a modern programming language designed for large,
 > long-lived applications – and embedded systems in particular –
@@ -54,9 +52,7 @@ Some test frameworks exist with
 **[Ahven](http://ahven.stronglytyped.org/)** is a unit test library
 for Ada which produces TAP 12 output.
 
-<a id="c"></a>
-
-## C
+## [C](#c) <a id="c"></a>
 
 > C is an imperative (procedural) language. It was designed to be compiled
 > using a relatively straightforward compiler, to provide low-level access
@@ -80,9 +76,7 @@ follows the [Test::More](http://perldoc.perl.org/Test/More.html) API.
 producer for C. This library is different from the MyTAP producer for MySQL.
 See [SQL](#sql).
 
-<a id="cplusplus"></a>
-
-## C++
+## [C++](#cplusplus) <a id="cplusplus"></a>
 
 > C++ is a general-purpose programming language with a bias towards
 > systems programming that: is a better C, supports data abstraction,
@@ -104,9 +98,7 @@ embedded within `libperl++`. It is a mostly complete port of
 **[libtappp](https://github.com/cbab/libtappp)** is a fork of `libtap++`
 that removes the build time dependency to [Boost](http://www.boost.org/).
 
-<a id="csharp"></a>
-
-## C&#35;
+## [C#](#csharp) <a id="csharp"></a>
 
 > C# is a multi-paradigm programming language encompassing strong typing,
 > imperative, declarative, functional, generic, object-oriented (class-based),
@@ -118,9 +110,7 @@ that removes the build time dependency to [Boost](http://www.boost.org/).
 .NET framework and Mono. It is inspired on Perl's testing facilities and
 is therefore quite different from tools like NUnit.
 
-<a id="common-lisp"></a>
-
-## Common Lisp
+## [Common Lisp](#common-lisp) <a id="common-lisp"></a>
 
 > Common Lisp is the modern, multi-paradigm, high-performance, compiled,
 > ANSI-standardized, most prominent (along with Scheme) descendant of the
@@ -139,9 +129,7 @@ designed to provide a common interface for Unit testing output.
 Currently, it supports TAP version 12 and xUnit style output.
 It is available via [Quicklisp](http://www.quicklisp.org/).
 
-<a id="erlang"></a>
-
-## Erlang
+## [Erlang](#erlang) <a id="erlang"></a>
 
 > Erlang is a programming language used to build massively scalable soft
 > real-time systems with requirements on high availability.
@@ -158,9 +146,7 @@ modules that provide a TAP testing client library. These modules are not
 meant to compete with eunit, but to offer a more general testing facility
 that isn't provided by eunit.
 
-<a id="fish"></a>
-
-## Fish
+## [Fish](#fish) <a id="fish"></a>
 
 > fish is a smart and user-friendly command line
 shell for OS X, Linux, and the rest of the family.
@@ -170,9 +156,7 @@ shell for OS X, Linux, and the rest of the family.
 **[Fishtape](http://github.com/fisherman/fishtape)** is a TAP producer
 and test harness for fish.
 
-<a id="forth"></a>
-
-## Forth
+## [Forth](#forth) <a id="forth"></a>
 
 > Forth is a computer language originally designed for embedded and
 > real-time applications.
@@ -184,9 +168,7 @@ Check out the [Testing with Forth](/testing-with-tap/forth.html) guide.
 **[gforth-tap](https://github.com/AndyA/gforth-tap)** is a TAP producer
 for Forth at an alpha level readiness.
 
-<a id="go"></a>
-
-## Go
+## [Go](#go) <a id="go"></a>
 
 > Go is an open source programming language that makes it easy to build
 > simple, reliable, and efficient software.
@@ -196,9 +178,7 @@ for Forth at an alpha level readiness.
 **[tap.go](https://github.com/mndrix/tap.go)** is a basic TAP producer
 for `testing/quick.Check` tests.
 
-<a id="haskell"></a>
-
-## Haskell
+## [Haskell](#haskell) <a id="haskell"></a>
 
 > Haskell is an advanced purely-functional programming language.
 >
@@ -212,9 +192,7 @@ that implements most of the
 used with the [Tasty](http://documentup.com/feuerbach/tasty) Haskell
 test framework.
 
-<a id="java"></a>
-
-## Java
+## [Java](#java) <a id="java"></a>
 
 > Java is a general-purpose computer programming language that is concurrent,
 > class-based, object-oriented, and specifically designed to have as
@@ -230,9 +208,7 @@ is a TAP library that implements most of the
 is integrated at the core of other Java projects like the
 [Jenkins TAP Plugin](https://wiki.jenkins-ci.org/display/JENKINS/TAP+Plugin).
 
-<a id="javascript"></a>
-
-## JavaScript
+## [JavaScript](#javascript) <a id="javascript"></a>
 
 > JavaScript is a prototype-based, multi-paradigm, dynamic scripting language,
 > supporting object-oriented, imperative, and functional programming styles.
@@ -269,9 +245,7 @@ JavaScript test framework.
 
 [node]: https://nodejs.org/en/
 
-<a id="limbo"></a>
-
-## Limbo (OS Inferno)
+## [Limbo (OS Inferno)](#limbo) <a id="limbo"></a>
 
 > Limbo is the application programming language for Inferno.
 > Syntactically similar to C, it has several features that make it simpler,
@@ -283,9 +257,7 @@ JavaScript test framework.
 **[inferno-contrib-tap](https://github.com/powerman/inferno-contrib-tap)**
 is a TAP producer that supports version 12.
 
-<a id="lua"></a>
-
-## Lua
+## [Lua](#lua) <a id="lua"></a>
 
 > Lua is a powerful, fast, lightweight, embeddable scripting language.
 >
@@ -298,9 +270,7 @@ for Lua with a built-in TAP output handler.
 a port of the [Test::More](http://perldoc.perl.org/Test/More.html) framework
 to Lua.
 
-<a id="matlab"></a>
-
-## MATLAB
+## [MATLAB](#matlab) <a id="matlab"></a>
 
 > MATLAB is a high-level language for numerical computation, visualization,
 > and application development.
@@ -312,9 +282,7 @@ is a plugin for the
 [matlab.unittest](http://www.mathworks.com/help/matlab/matlab-unit-test-framework.html)
 framework that produces output in the TAP version 12 format.
 
-<a id="ocaml"></a>
-
-## OCaml
+## [OCaml](#ocaml) <a id="ocaml"></a>
 
 > OCaml is an industrial strength programming language supporting functional,
 > imperative and object-oriented styles.
@@ -324,9 +292,7 @@ framework that produces output in the TAP version 12 format.
 **[TestSimple](https://github.com/hcarty/ocaml-testsimple)** is a simple
 unit testing framework based on Perl's very successful Test::\* modules.
 
-<a id="pascal"></a>
-
-## Pascal
+## [Pascal](#pascal) <a id="pascal"></a>
 
 > Pascal is a historically influential imperative and procedural
 > programming language, designed as a small and efficient language
@@ -339,9 +305,7 @@ unit testing framework based on Perl's very successful Test::\* modules.
 is a very easy-to-use, but powerful unit testing suite for Pascal
 (FreePascal, Turbo Pascal, et al), conforming to the TAP specification.
 
-<a id="perl"></a>
-
-## Perl
+## [Perl](#perl) <a id="perl"></a>
 
 > Perl is a general-purpose programming language originally developed for
 > text manipulation and now used for a wide range of tasks including
@@ -365,9 +329,7 @@ There are more ambitious Perl modules out there, such as
 [Test::More](http://perldoc.perl.org/Test/More.html) and
 [Test::Unit](http://search.cpan.org/perldoc?Test%3A%3AUnit).
 
-<a id="php"></a>
-
-## PHP
+## [PHP](#php) <a id="php"></a>
 
 > PHP (recursive acronym for PHP: Hypertext Preprocessor) is a widely-used
 > open source general-purpose scripting language that is especially suited
@@ -395,9 +357,7 @@ framework for PHP with an interface like
 PHP testing library based on
 [Test::More](http://perldoc.perl.org/Test/More.html).
 
-<a id="prolog"></a>
-
-## Prolog
+## [Prolog](#prolog) <a id="prolog"></a>
 
 > Prolog is a general purpose logic programming language that
 > has its roots in first-order logic, a formal logic, and unlike many
@@ -410,9 +370,7 @@ PHP testing library based on
 written for [SWI-Prolog](http://www.swi-prolog.org/), but may work with
 other Prologs.
 
-<a id="python"></a>
-
-## Python
+## [Python](#python) <a id="python"></a>
 
 > Python is an easy to learn, powerful programming language. It has efficient
 > high-level data structures and a simple but effective approach to
@@ -437,9 +395,7 @@ and plugins that output TAP for
 [nose](https://nose.readthedocs.org/en/latest/) and
 [pytest](http://pytest.org/latest/).
 
-<a id="ruby"></a>
-
-## Ruby
+## [Ruby](#ruby) <a id="ruby"></a>
 
 > Ruby is a dynamic, open source programming language with a focus on
 > simplicity and productivity. It has an elegant syntax that is natural
@@ -454,9 +410,7 @@ and plugins that output TAP for
 configurable tool for writing clean and consistent 
 [SCSS](http://sass-lang.com) that supports TAP output.
 
-<a id="shell"></a>
-
-## Shell
+## [Shell](#shell) <a id="shell"></a>
 
 > A shell script is a computer program designed to be run by the Unix shell,
 > a command line interpreter. The various dialects of shell scripts are
@@ -483,9 +437,7 @@ Since all tests output TAP, they can be run with any TAP harness.
 **[Tapper-autoreport](https://github.com/tapper/Tapper-autoreport)**
 turns bash scripts into TAP test scripts.
 
-<a id="sql"></a>
-
-## SQL
+## [SQL](#sql) <a id="sql"></a>
 
 > SQL (Structured Query Language) is a special-purpose programming language
 > designed for managing data held in a relational database management system
@@ -510,9 +462,7 @@ is a script for testing with Oracle's
 [PL/SQL](http://www.oracle.com/technetwork/database/features/plsql/index.html)
 procedural extension for SQL.
 
-<a id="typescript"></a>
-
-## TypeScript
+## [TypeScript](#typescript) <a id="typescript"></a>
 
 > TypeScript is a free and open source programming language developed and
 > maintained by Microsoft. It is a strict superset of JavaScript.
@@ -522,9 +472,7 @@ procedural extension for SQL.
 **[TypeSpec](https://github.com/Steve-Fenton/TypeSpec)** is a BDD framework
 for TypeScript with a built-in TapReporter class for TAP compliant output.
 
-<a id="frameworks"></a>
-
-## Test frameworks
+## [Test frameworks](#frameworks) <a id="frameworks"></a>
 
 Some test frameworks solve problems that are not specific to a programming
 language. These frameworks might be used for infrastructure or other kinds

--- a/tap-ietf-draft.md
+++ b/tap-ietf-draft.md
@@ -94,6 +94,7 @@ The complete flow in this system can look something like this:
 ```
 
 Additionally, utilities like "prove" can further simplify running a suite of TAP producers, by searching for files having certain characteristics or matching particular patterns. For instance, conventionally, all tests for a Perl module are stored in the 't/' folder, and consist of executable scripts (TAP producers) with extensions of 't'. The "prove" utility, part of the Test::Harness module, can then be used to find these files and run them all. In the following example, prove executes t/error.t, t/id.t and t/url.t and evaluates the produced TAP streams in turn, checking which ones passed and failed, and providing a complete summary of the entire test suite run.
+
 ```
 $ prove t/*.t
 t/error.t...ok   
@@ -262,6 +263,7 @@ An example of the use of this option is to check exit codes of TAP producers for
 See [RFC 3552](http://www.apps.ietf.org/rfc/rfc3552.html) for tips on how to write this section.
 Problems with parsing debugging status?
 A parser which stores test results in a dynamically sized array may be vulnerable to memory starvation by a test which uses a very high test number. For example...
+
 ```
   1..3
   ok 1

--- a/testing-with-tap/c-plus-plus.md
+++ b/testing-with-tap/c-plus-plus.md
@@ -9,27 +9,27 @@ title: Testing with C++
 
 ### SYNOPSIS
 
-```
- #include <tap++/tap++.h>
- #include <string>
+```cpp
+#include <tap++/tap++.h>
+#include <string>
 
- using namespace TAP;
+using namespace TAP;
 
- int foo() {
-   return 1;
- }
+int foo() {
+  return 1;
+}
 
- std::string bar() {
-   return "a string";
- }
+std::string bar() {
+  return "a string";
+}
 
- int main() {
-   plan(3);
-   ok(true, "This test passes");
-   is(foo(), 1, "foo() should be 1");
-   is(bar(), "a string", "bar() should be \"a string\"");
-   return exit_status();
- }
+int main() {
+  plan(3);
+  ok(true, "This test passes");
+  is(foo(), 1, "foo() should be 1");
+  is(bar(), "a string", "bar() should be \"a string\"");
+  return exit_status();
+}
 ```
 
 Remember to link with libtap++. For example: `g++ -ltap++ tap-synopsis.o -o tap-synopsis`
@@ -52,10 +52,10 @@ Before anything else, you need a testing plan. This basically declares how many 
 
 #### plan()
 
-```
- void plan(int number_of_tests);
- void plan(skip_all, const std::string& reason="");
- void plan(no_plan);
+```cpp
+void plan(int number_of_tests);
+void plan(skip_all, const std::string& reason="");
+void plan(no_plan);
 ```
 
 The function plan is used to indicate the plan of your test run. Usually you will just give it the number of tests as argument.
@@ -64,9 +64,9 @@ Alternatively, you can give it the skip_all or no_plan constants as arguments. T
 
 #### done_testing()
 
-```
- void done_testing();
- void done_testing(int number_of_tests);
+```cpp
+void done_testing();
+void done_testing(int number_of_tests);
 ```
 
 If you don't know how many tests you're going to run, you can issue the plan when you're done running tests.
@@ -78,17 +78,17 @@ This is safer than and replaces the "no_plan" plan.
 By convention, each test is assigned a number in order. This is largely done automatically for you. However, it's often very useful to assign a name to each test. Which would you rather see:
 
 ```
- ok 4
- not ok 5
- ok 6
+ok 4
+not ok 5
+ok 6
 ```
 
 or
 
 ```
- ok 4 - basic multi-variable
- not ok 5 - simple exponential
- ok 6 - force == mass * acceleration
+ok 4 - basic multi-variable
+not ok 5 - simple exponential
+ok 6 - force == mass * acceleration
 ```
 
 The later gives you some idea of what failed. It also makes it easier to find the test in your script, simply search for "simple exponential".
@@ -101,59 +101,61 @@ All of the following print "ok" or "not ok" depending on if the test succeeded o
 
 #### ok()
 
-```
- bool ok(bool condition, const std::string& test_name = "");
+```cpp
+bool ok(bool condition, const std::string& test_name = "");
 ```
 
 ok is the basic test expression in TAP. It simply evaluates any expression, for example, got == expected, taking a true value to mean that the test passed and a false value to mean that the test failed.
 test_name is a very short description of the test that will be printed out. It makes it very easy to find a test in your script when it fails and gives others an idea of your intentions. test_name is optional, but we very strongly encourage its use.
 
-####is(); isnt()
+#### is(); isnt()
 
-```
- template<typename T, typename U> bool is(const T& got, const U& expected, std::string& test_name = "");
- template<typename T, typename U> bool isnt(const T& got, const U& expected, std::string& test_name = "");
+```cpp
+template<typename T, typename U> bool is(
+  const T& got, const U& expected, std::string& test_name = "");
+template<typename T, typename U> bool isnt(
+  const T& got, const U& expected, std::string& test_name = "");
 ```
 
 Similar to ok(), is() and isnt() compare their two arguments with == and != respectively and use the result of that to determine if the test succeeded or failed. So these:
 
-```
-   # Is the ultimate answer 42?
-   is( ultimate_answer(), 42, "Meaning of Life" );
+```cpp
+# Is the ultimate answer 42?
+is(ultimate_answer(), 42, "Meaning of Life");
 
-   # foo isn't empty
-   isnt( foo, "",     "Got some foo" );
+# foo isn't empty
+isnt(foo, "", "Got some foo");
 ```
 
 are similar to these:
 
-```
-   ok( ultimate_answer() == 42, "Meaning of Life" );
-   ok( foo != "", "Got some foo" );
+```cpp
+ok(ultimate_answer() == 42, "Meaning of Life");
+ok(foo != "", "Got some foo");
 ```
 
 (Mnemonic: "This is that." "This isn't that.")
 So why use these? They produce better diagnostics on failure. ok() cannot know what you are testing for (beyond the name), but is() and isnt() know what the test was and why it failed. For example this test:
 
-```
-   std::string foo("waffle"), bar("yarblokos");
-   is( foo, bar, 'Is foo the same as bar?' );
+```cpp
+std::string foo("waffle"), bar("yarblokos");
+is(foo, bar, "Is foo the same as bar?");
 ```
 
 Will produce something like this:
 
 ```
-   not ok 17 - Is foo the same as bar?
-   #   Failed test 'Is foo the same as bar?'
-   #          got: 'waffle'
-   #     expected: 'yarblokos'
+not ok 17 - Is foo the same as bar?
+#   Failed test 'Is foo the same as bar?'
+#          got: 'waffle'
+#     expected: 'yarblokos'
 ```
 
 #### pass(); fail()
 
-```
- bool pass(const std::string& test_name = "");
- bool fail(const std::string& test_name = "");
+```cpp
+bool pass(const std::string& test_name = "");
+bool fail(const std::string& test_name = "");
 ```
 
 Sometimes you just want to say that the tests have passed. Usually the case is you've got some complicated condition that is difficult to wedge into an ok(). In this case, you can simply use pass() (to declare the test ok) or fail (for not ok). They are synonyms for ok(true, test_name) and ok(false, test_name).
@@ -163,8 +165,8 @@ Use these very, very, very sparingly.
 
 #### skip()
 
-```
- void skip(int number, const std::string& reason = "");
+```cpp
+void skip(int number, const std::string& reason = "");
 ```
 
 skip tells the TAP harness that you're skipping a number of tests for the given reason. Note that you have to do the skipping yourself.
@@ -175,25 +177,25 @@ If you pick the right test function, you'll usually get a good idea of what went
 
 #### diag
 
-```
- diag(diagnostic_message...);
+```cpp
+diag(diagnostic_message...);
 ```
 
 Prints a diagnostic message which is guaranteed not to interfere with test output. The arguments are simply concatenated together.
 Returns false, so as to preserve failure.
 Handy for this sort of thing:
 
-```
-       ok( has_user("foo"), "There's a foo user" ) or
-       diag("Since there's no foo, check that /etc/bar is set up right");
+```cpp
+ok(has_user("foo"), "There's a foo user") or
+diag("Since there's no foo, check that /etc/bar is set up right");
 ```
 
 which would produce:
 
 ```
-   not ok 42 - There's a foo user
-   #   Failed test 'There's a foo user'
-   # Since there's no foo, check that /etc/bar is set up right.
+not ok 42 - There's a foo user
+#   Failed test 'There's a foo user'
+# Since there's no foo, check that /etc/bar is set up right.
 ```
 
 You might remember ok() or diag() with the mnemonic open() or die().
@@ -202,24 +204,24 @@ You might remember ok() or diag() with the mnemonic open() or die().
 
 #### note
 
-```
- note(diagnostic_message...);
+```cpp
+note(diagnostic_message...);
 ```
 
 Like diag(), except the message will not be seen when the test is run in a harness. It will only be visible in the verbose TAP stream.
 Handy for putting in notes which might be useful for debugging, but don't indicate a problem.
 
-```
-  note("Tempfile is ", tempfile);
+```cpp
+note("Tempfile is ", tempfile);
 ```
 
 diag simply catenates its arguments to the error output, while note prints diagnostics to the TAP stream.
 
 #### set_output(); set_error()
 
-```
- void set_output(std::ofstream& new_output);
- void set_error(std::ofstream& new_error);
+```cpp
+void set_output(std::ofstream& new_output);
+void set_error(std::ofstream& new_error);
 ```
 
 These set the filehandle of the TAP stream and the error stream. They default to std::cout and std::cerr, respectively. These can only be set before any output is written to them.
@@ -232,18 +234,18 @@ If all your tests passed, Test::Builder will exit with zero (which is normal). I
 So the exit codes are...
 
 ```
-   0                   all tests successful
-   255                 test died or all passed but wrong # of tests run
-   any other number    how many failed (including missing or extras)
+0                   all tests successful
+255                 test died or all passed but wrong # of tests run
+any other number    how many failed (including missing or extras)
 ```
 
 If you fail more than 254 tests, it will be reported as 254.
 
 #### bail_out()
 
-```
- int exit_status();
- void bail_out(const std::string& reason);
+```cpp
+int exit_status();
+void bail_out(const std::string& reason);
 ```
 
 **bail_out** terminates the current test program with exit code 255, indicating to the test harness that all subsequent testing should halt. Typically this is used to indicate that testing cannot continue at all.

--- a/testing-with-tap/forth.md
+++ b/testing-with-tap/forth.md
@@ -25,28 +25,28 @@ You may not be familiar with [Forth](https://en.wikipedia.org/wiki/Forth_(progra
 It's recommended that whenever possible your TAP should start with a plan. The plan says how many tests are expected to run and looks like this:
 
 ```
- 1..10
+1..10
 ```
 
 The plan always takes the form 1..*number* of tests.
 In Forth we can output a plan like this:
 
 ```
- ." 1..10" cr
+." 1..10" cr
 ```
 
 Or you can define the word plan like this:
 
 ```
- : plan ( n -- )
-     ." 1.." . cr
- ;
+: plan ( n -- )
+    ." 1.." . cr
+;
 ```
 
 and use it like this:
 
 ```
- 10 plan
+10 plan
 ```
 
 ### Test results
@@ -54,32 +54,32 @@ and use it like this:
 The general form of a test result is either
 
 ```
- ok test-number description
+ok test-number description
 ```
 
 or
 
 ```
- not ok test-number description
+not ok test-number description
 ```
 
 The description is optional so we'll omit it for now and concentrate on generating results that a TAP parser can process.
 We need a variable to hold the number of the next test. In Forth that looks like this:
 
 ```
- Variable test# 
- 0 test# !
+Variable test# 
+0 test# !
 ```
 
 And we need something to output the result:
 
 ```
- : ok ( f -- )
- 	0= if ." not " then
- 	." ok "
- 	test# dup @ 1+ dup . swap !
- 	cr
- ;
+: ok ( f -- )
+	0= if ." not " then
+	." ok "
+	test# dup @ 1+ dup . swap !
+	cr
+;
 ```
 
 Now we have a word called ok which checks the top value on the stack and outputs 'ok' or 'not ok' depending on whether it's true (non-zero) or false (zero). With that we have everything necessary to start TAP based testing.
@@ -90,23 +90,23 @@ Now we have a word called ok which checks the top value on the stack and outputs
 Here's a simple test of addition and subtraction using the words we just defined:
 
 ```
- #! /usr/local/bin/gforth
- 
- require tap.fs
- 
- 2 plan
- 1 1 + 2 = ok
- 2 1 - 1 = ok
- 
- bye
+#! /usr/local/bin/gforth
+
+require tap.fs
+
+2 plan
+1 1 + 2 = ok
+2 1 - 1 = ok
+
+bye
 ```
 
 It assumes that we saved our TAP generating code in a file called tap.fs. When run it will output
 
 ```
- 1..2
- ok 1
- ok 2
+1..2
+ok 1
+ok 2
 ```
 
 ### Analysing the results
@@ -114,13 +114,13 @@ It assumes that we saved our TAP generating code in a file called tap.fs. When r
 If you have the Perl prove utility (which is part of [Test::Harness](http://search.cpan.org/dist/Test-Harness/) you can use it to run this test script and analyse the results:
 
 ```
- $ prove -v simple.fs
- t/simple...1..2 
- ok 1 
- ok 2 
- ok
- All tests successful.
- Files=1, Tests=2,  0 wallclock secs ( 0.01 cusr +  0.02 csys =  0.03 CPU)
+$ prove -v simple.fs
+t/simple...1..2 
+ok 1 
+ok 2 
+ok
+All tests successful.
+Files=1, Tests=2,  0 wallclock secs ( 0.01 cusr +  0.02 csys =  0.03 CPU)
 ```
 
 #### Get the code

--- a/testing-with-tap/java.md
+++ b/testing-with-tap/java.md
@@ -9,9 +9,9 @@ title: Testing with Java
 
 ### Installation
 
-In order to install tap4j you have to download a jar from (http://tap4j.sourceforge.net)[http://tap4j.sourceforge.net] or if you are a Maven user you can add a dependency in your pom.xml, as shown below.
+In order to install tap4j you have to download a jar from [http://tap4j.sourceforge.net](http://tap4j.sourceforge.net) or if you are a Maven user you can add a dependency in your pom.xml, as shown below.
 
-```
+```xml
 <dependency>
  <groupid>br.eti.kinoshita</groupid>
  <artifactid>tap4j</artifactid>
@@ -24,7 +24,7 @@ Differently than in others implementations, tap4j uses an Object Oriented approa
 
 The TAP Producers in tap4j are created using a [TapProducerFactory](http://tap4j.sourceforge.net/apidocs/org/tap4j/producer/TapProducerFactory.html). After a TAP Producer is created we can call the dump method passing a [TestSet](http://tap4j.sourceforge.net/apidocs/org/tap4j/model/TestSet.html) to have the result TAP.
 
-```
+```java
 TapProducer tapProducer = TapProducerFactory.makeTap13Producer();
 testSet testSet = new testSet();
 
@@ -57,7 +57,7 @@ not ok 2
 
 If you understood about how tap4j works, reading a TAP Stream will be quite easy for you. You just have to create a TAP Consumer using guess what? Yeah, a [TapConsumerFactory](http://tap4j.sourceforge.net/apidocs/org/tap4j/consumer/TapConsumerFactory.html). The method of the TAP Consumer to load TAP is load(). This method will return a [TestSet](http://tap4j.sourceforge.net/apidocs/org/tap4j/model/TestSet.html). Let's read the output from the previous section.
 
-```
+```java
 TapConsumer tapConsumer = TapConsumerFactory.makeTap13Consumer();
 String tapStream = "1..2\n" +
 		"ok 1\n" +

--- a/testing-with-tap/ruby.md
+++ b/testing-with-tap/ruby.md
@@ -7,41 +7,39 @@ title: Testing with Ruby
 
 Testing with Ruby is pretty easy, however, there is a lesser known Ruby program, that produces TAP output (on demand). This handy program is [bacon](http://github.com/chneukirchen/bacon/tree/master). You can install it using the RubyGems Ruby package management system. Just do (possibly as a privileged user):
 
-```
-   # gem install bacon
+```bash
+$ gem install bacon
 ```
 
 Now you can create tests. Create a Ruby file test.rb (or something like that):
 
-```
-
-  describe "a example test suite" do
-    it "should consider true as the truth" do
-      true.should.be.true
-    end
-    
-    it "should consider false as the truth, too" do
-      false.should.be.true
-    end
+```ruby
+describe "a example test suite" do
+  it "should consider true as the truth" do
+    true.should.be.true
   end
 
+  it "should consider false as the truth, too" do
+    false.should.be.true
+  end
+end
 ```
 
 Once you created your this file, you can issue the command
 
-```
+```bash
 $ bacon test.rb --tap
 ```
 
 which, in turn, produces the following TAP output (Version 12)
 
 ```
- ok 1   - should consider true as the truth
- not ok 2 - should consider false as the truth, too: FAILED
- # Bacon::Error: false.true?() failed
- # 	./test.rb:7: a example test suite - should consider false as the truth, too
- # 	./test.rb:6
- # 	./test.rb:1
- 1..2
- # 2 tests, 2 assertions, 1 failures, 0 errors
+ok 1   - should consider true as the truth
+not ok 2 - should consider false as the truth, too: FAILED
+# Bacon::Error: false.true?() failed
+# 	./test.rb:7: a example test suite - should consider false as the truth, too
+# 	./test.rb:6
+# 	./test.rb:1
+1..2
+# 2 tests, 2 assertions, 1 failures, 0 errors
 ```


### PR DESCRIPTION
Since GitHub is deprecating all other markdown libraries except kramdown, this branch switches from redcarpet to kramdown.

The switch to kramdown broke a bunch of the pages. Generally:
* I fixed many broken headlines. kramdown seems to be far more picky about whitespace around things.
* I updated all the fenced code blocks. With this change, I also took the chance to add languages so that the site will actually colorize language samples.
* I had to fiddle with some styling because the switch from pygments to rouge changed some of the underlying markup CSS classes.
* I tried to unify and improve the look of code blocks and blockquotes.

In order to get local rendering to be the same as GitHub Pages' rendering, I added some explicit settings for kramdown to make sure things behaved similarly. https://help.github.com/articles/configuring-jekyll/

Sorry for the big diff. The vast majority of this is whitespace changes so I think it should be fairly quick to go over.

Fixes #91