### PR TITLE
Clean up the structure of the consumers page.

### DIFF
--- a/consumers.md
+++ b/consumers.md
@@ -20,22 +20,16 @@ Languages:
 and
 [Others](#others).
 
-<a id="c"></a>
-
-## C
+## [C](#c) <a id="c"></a>
 
 - [C Tap Harness](http://www.eyrie.org/~eagle/software/c-tap-harness/)
 - [YACC parser](https://github.com/ligurio/tap-parser)
 
-<a id="java"></a>
-
-## Java
+## [Java](#java) <a id="java"></a>
 
 - [tap4j](http://sourceforge.net/projects/tap4j/)
 
-<a id="javascript"></a>
-
-## JavaScript
+## [JavaScript](#javascript) <a id="javascript"></a>
 
 - [node-tap](https://www.npmjs.com/package/tap)
 - [TAP parser](https://www.npmjs.com/package/tap-parser)
@@ -43,9 +37,7 @@ and
 - [Testling](https://ci.testling.com/guide/local_tests) consumes browser
   test output for any browser test suite that outputs TAP to `console.log`.
 
-<a id="perl"></a>
-
-## Perl
+## [Perl](#perl) <a id="perl"></a>
 
 - [TAP::Parser](http://search.cpan.org/dist/Test-Harness/lib/TAP/Parser.pm)
 - [Test::Harness](http://search.cpan.org/dist/Test-Harness/lib/Test/Harness.pm)
@@ -55,15 +47,11 @@ and
 - [metatap](http://search.cpan.org/search?query=metatap)
 - [Tapper test infrastructure](http://tapper-testing.org)
 
-<a id="python"></a>
-
-## Python
+## [Python](#python) <a id="python"></a>
 
 - [tappy](https://pypi.python.org/pypi/tap.py)
 
-<a id="others"></a>
-
-## Others
+## [Others](#others) <a id="others"></a>
 
 - [Jenkins TAP Plugin](https://wiki.jenkins-ci.org/display/JENKINS/TAP+Plugin)
 - [Desktop notifications](https://github.com/ryandoyle/shouldertap)

--- a/consumers.md
+++ b/consumers.md
@@ -5,57 +5,82 @@ title: TAP Consumers
 
 # TAP Consumers
 
-Things that can take TAP as an input and do something useful with it.
+TAP consumers are systems that can take TAP as an input
+and do something useful with it.
+This page contains a catalog of software libraries
+that can act as TAP consumers,
+grouped by programming language.
 
-## Perl
+Languages:
+[C](#c),
+[Java](#java),
+[JavaScript](#javascript),
+[Perl](#perl),
+[Python](#python),
+and
+[Others](#others).
 
--    [TAP::Parser](http://search.cpan.org/dist/Test-Harness/lib/TAP/Parser.pm)
--    [Test::Harness](http://search.cpan.org/dist/Test-Harness/lib/Test/Harness.pm)
--    [Test::Run](http://search.cpan.org/dist/Test-Run/lib/Test/Run.pm)
--    [Smolder project background](http://sourceforge.net/projects/smolder/)
--    [TapTinder](http://dev.taptinder.org/wiki/TapTinder)
--    [metatap](http://search.cpan.org/search?query=metatap)
--    [Tapper test infrastructure](http://tapper-testing.org)
-
-## Python
-
--    [tappy](https://pypi.python.org/pypi/tap.py)
-
-## Java
-
--    [tap4j](http://sourceforge.net/projects/tap4j/)
-
-## JavaScript
-
--    [node-tap](https://www.npmjs.com/package/tap)
--    [TAP parser](https://www.npmjs.com/package/tap-parser)
--    [tape](https://www.npmjs.com/package/tape)
--    [Testling](https://ci.testling.com/guide/local_tests) consumes browser
-     test output for any browser test suite that outputs TAP to `console.log`.
+<a id="c"></a>
 
 ## C
 
--    [C Tap Harness](http://www.eyrie.org/~eagle/software/c-tap-harness/)
--    [YACC parser](https://github.com/ligurio/tap-parser)
+- [C Tap Harness](http://www.eyrie.org/~eagle/software/c-tap-harness/)
+- [YACC parser](https://github.com/ligurio/tap-parser)
+
+<a id="java"></a>
+
+## Java
+
+- [tap4j](http://sourceforge.net/projects/tap4j/)
+
+<a id="javascript"></a>
+
+## JavaScript
+
+- [node-tap](https://www.npmjs.com/package/tap)
+- [TAP parser](https://www.npmjs.com/package/tap-parser)
+- [tape](https://www.npmjs.com/package/tape)
+- [Testling](https://ci.testling.com/guide/local_tests) consumes browser
+  test output for any browser test suite that outputs TAP to `console.log`.
+
+<a id="perl"></a>
+
+## Perl
+
+- [TAP::Parser](http://search.cpan.org/dist/Test-Harness/lib/TAP/Parser.pm)
+- [Test::Harness](http://search.cpan.org/dist/Test-Harness/lib/Test/Harness.pm)
+- [Test::Run](http://search.cpan.org/dist/Test-Run/lib/Test/Run.pm)
+- [Smolder project background](http://sourceforge.net/projects/smolder/)
+- [TapTinder](http://dev.taptinder.org/wiki/TapTinder)
+- [metatap](http://search.cpan.org/search?query=metatap)
+- [Tapper test infrastructure](http://tapper-testing.org)
+
+<a id="python"></a>
+
+## Python
+
+- [tappy](https://pypi.python.org/pypi/tap.py)
+
+<a id="others"></a>
 
 ## Others
 
--    [Jenkins TAP Plugin](https://wiki.jenkins-ci.org/display/JENKINS/TAP+Plugin)
--    [Desktop notifications](https://github.com/ryandoyle/shouldertap)
--    Automake 1.13+ can [run TAP tests](https://www.gnu.org/software/automake/manual/html_node/Using-the-TAP-test-protocol.html#Using-the-TAP-test-protocol) for `make check`, via `tap-driver.sh`.
--   [Kyua](https://github.com/jmmv/kyua) Testing framework for infrastructure software.
+- [Jenkins TAP Plugin](https://wiki.jenkins-ci.org/display/JENKINS/TAP+Plugin)
+- [Desktop notifications](https://github.com/ryandoyle/shouldertap)
+- Automake 1.13+ can [run TAP tests](https://www.gnu.org/software/automake/manual/html_node/Using-the-TAP-test-protocol.html#Using-the-TAP-test-protocol) for `make check`, via `tap-driver.sh`.
+- [Kyua](https://github.com/jmmv/kyua) Testing framework for infrastructure software.
 
 
 ## Universal desirable behaviors
 
--    These are behaviors desired in all TAP parsers.
--    Should work on the TAP as a stream (ie. as each line is received) rather than wait until all the TAP is received.
--    The TAP source should be pluggable (ie. don't assume its always coming from a Perl program).
--    The TAP display should be pluggable.
--    Should be able to gracefully handle future upgrades to TAP.
--    Should be forward compatible.
-     -    Ignore unknown directives
-     -    Ignore any unparsable lines
+- These are behaviors desired in all TAP parsers.
+- Should work on the TAP as a stream (ie. as each line is received) rather than wait until all the TAP is received.
+- The TAP source should be pluggable (ie. don't assume its always coming from a Perl program).
+- The TAP display should be pluggable.
+- Should be able to gracefully handle future upgrades to TAP.
+- Should be forward compatible.
+  - Ignore unknown directives
+  - Ignore any unparsable lines
 
 ### Non Proliferation
 

--- a/css/main.css
+++ b/css/main.css
@@ -41,12 +41,16 @@ h1 {
 
 h2 {
   font-size: 1.5em;
-  line-height: 2em;
+  margin: 1em 0;
 }
 
 h3 {
   font-size: 1em;
   line-height: 2em;
+}
+
+ul {
+  margin: 1em 0;
 }
 
 ul li {
@@ -88,6 +92,18 @@ div.highlight pre {
 
 .clear {
   clear:both;
+}
+
+/* Section links */
+h2 a {
+  color: #000;
+  text-decoration: none;
+}
+h2 a:hover {
+  text-decoration: underline;
+}
+h2 a:visited {
+  color: #000;
 }
 
 /*****************************************************************************/


### PR DESCRIPTION
This branch adds a similar structure to the consumers page as on the producers page. I added navigation to each section, updated the intro paragraph, and sorted the sections by language. The content in each section remains unchanged (aside from some minor whitespace modifications).