### PR TITLE
Fix markdown headline rendering

### DIFF
--- a/philosophy.md
+++ b/philosophy.md
@@ -5,7 +5,7 @@ title: TAP Philosophy
 
 # TAP Philosophy
 
-##Universal desirable behaviors for parsers
+## Universal desirable behaviors for parsers
 
 These are behaviors desired in all TAP parsers:
 


### PR DESCRIPTION
That h2 currently appears as plain text `##Universal …` on <http://testanything.org/philosophy.html>