### PR TITLE
Fix typo in markdown syntax

### DIFF
--- a/tap-specification.md
+++ b/tap-specification.md
@@ -3,8 +3,7 @@ layout: default
 title: TAP specification
 ---
 
-# TAP specification
-## NAME
+# NAME
 
 TAP - The Test Anything Protocol
 


### PR DESCRIPTION
Just a typo in the `tap-specification.md`.

I choose to fit with tap `tap-version-13-specification.md` format instead of adding a line break.