### PR TITLE
Remove LGTM related files.

### DIFF
--- a/.lgtm
+++ b/.lgtm
@@ -1,2 +1,0 @@
-approvals = 1
-pattern = "(?i):shipit:|:\\+1:|LGTM"

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,5 +1,0 @@
-jonathanKingston
-mblayman
-isaacs
-Leont
-kinow


### PR DESCRIPTION
The service is long gone. I'm hoping that removing these files will
eliminate the PR approval checks because removing the webhook didn't do
the trick.