### PR TITLE
Adding BaseT to JS producers list

### DIFF
--- a/producers.md
+++ b/producers.md
@@ -268,6 +268,8 @@ is integrated at the core of other Java projects like the
 **[AVA](https://github.com/sindresorhus/ava)** an asynchronous test framework
 combining plans and tests and has an optional TAP reporter.
 
+**[BaseT](https://github.com/Igmat/baset)** a test tool that implements Baseline Strategy (very close to snapshot testing) with TAP output ([tap diff](https://github.com/axross/tap-diff) is default reporter).
+
 **[BusterJS](http://busterjs.org)** is a JavaScript testing toolkit for
 both [Node.js][node] and browsers that comes with a
 [TAP reporter](http://docs.busterjs.org/en/latest/overview/#reporters).


### PR DESCRIPTION
I've added mention for [BaseT](https://github.com/Igmat/baset) - test tool for JavaScript that I'm working on now. It produces TAP output, so this link could be helpful for others.

It doesn't look like common test framework, but tries to provide a little bit different testing approach in JS ecosystem.

---
P.S.
I'll be grateful for any kind of feedback on tool itself, too:)