### PR TITLE
Fix Java section header level in spec

### DIFF
--- a/tap-specification.md
+++ b/tap-specification.md
@@ -382,7 +382,7 @@ http://search.cpan.org/dist/Apache-Test/
 
 (Geoffrey Young, April 17, 2006)
 
-### Java
+## Java
 tap4j provides objects to create TestSets, TestResults, BailOuts and, using a TapProducer, dump it into a java.io.File or String. It also provides TapConsumer's to load TapStreams from Strings or java.io.File's. YAMLish is interpreted and made available as diagnostics of each TestResult object of a TestSet.
 
 -    [tap4j](http://www.tap4j.org)


### PR DESCRIPTION
All the other language section headers are H2