### PR TITLE
Use two backticks in paragraph to avoid yaml char conversion

### DIFF
--- a/tap-version-14-specification.md
+++ b/tap-version-14-specification.md
@@ -511,7 +511,7 @@ were not tested, if that is appropriate for their use case.
 ### YAML Diagnostics
 
 If a Test Point is followed by a 2-space indented block beginning with the
-line `  ---` and ending with the line `  ...`, separated from the Test
+line ``  ---`` and ending with the line ``  ...``, separated from the Test
 Point only by comments or whitespace, then the block of lines between these
 markers will be interpreted as an inline YAML Diagnostic document according
 to version 1.2 of the [YAML specification](https://yaml.org).


### PR DESCRIPTION
Closes https://github.com/TestAnything/Specification/issues/44

Before:

![image](https://user-images.githubusercontent.com/304786/215211579-bedc4a83-6f03-4fa9-a5d1-8e4ddab8b680.png)

After this change:

![image](https://user-images.githubusercontent.com/304786/215212529-2665d341-6ec6-4d96-ad5c-d09e4da69450.png)

Thank you @bigsmoke for reporting it.

-Bruno