### PR TITLE
Added information about new fork of LibTAP++ that supports modern C++…

### DIFF
--- a/producers.md
+++ b/producers.md
@@ -123,12 +123,17 @@ Looking for a guide?
 is a TAP producer for [GoogleTest](https://github.com/google/googletest),
 Google's C++ test framework.
 
-**[libtap++](https://github.com/Leont/libperl--)** is a TAP library
-embedded within `libperl++`. It is a mostly complete port of
-[Test::More](http://perldoc.perl.org/Test/More.html) to C++.
+**[LibTAP++](https://gitlab.com/dhyannataraj/libtappp)** is a TAP producer for
+C++ programs. It is a mostly complete port of
+[Test::More](http://perldoc.perl.org/Test/More.html) to C++. This library
+supports modern C++ standards.
 
-**[libtappp](https://github.com/cbab/libtappp)** is a fork of `libtap++`
-that removes the build time dependency to [Boost](http://www.boost.org/).
+Legacy versions:
+- **[libtap++](https://github.com/Leont/libperl--)** is embedded within
+`libperl++`. It has the build time dependency to [Boost](http://www.boost.org/).
+
+- **[libtappp](https://github.com/cbab/libtappp)** older fork of `libtap++`
+that does not support modern C++ standards.
 
 **[QtTest](https://doc.qt.io/qt-6/qttest-index.html)** is the testing
 framework of [The Qt Project](https://www.qtproject.org/) and supports

--- a/testing-with-tap/c-plus-plus.md
+++ b/testing-with-tap/c-plus-plus.md
@@ -5,7 +5,7 @@ title: Testing with C++
 
 # Testing with C++
 
-## Testing using libtap++
+## Testing using LibTAP++
 
 ### SYNOPSIS
 
@@ -32,15 +32,16 @@ int main() {
 }
 ```
 
-Remember to link with libtap++. For example: `g++ -ltap++ tap-synopsis.o -o tap-synopsis`
+Remember to link with LibTAP++. For example: `g++ -ltap++ tap-synopsis.o -o tap-synopsis`
 
 ### DESCRIPTION
 
-libtap++ is a TAP producer for C++ programs. It tries to follow the interface of Test::More as much as possible, while at the same time making use of the full extent of C++'s features.
+LibTAP++ is a TAP producer for C++ programs. It tries to follow the interface of Test::More as much as possible, while at the same time making use of the full extent of C++'s features.
 
 ### Getting libtap++
 
-libtap++ is currently part of libperl-- hosted on github. It can be downloaded at [https://github.com/Leont/libperl--](https://github.com/Leont/libperl--).
+Latest version of LibTAP++, that is adapted to the latest C++ standards can
+be found at [https://gitlab.com/dhyannataraj/libtappp](https://gitlab.com/dhyannataraj/libtappp)
 
 ### FUNCTIONS
 


### PR DESCRIPTION
… standards

Some time ago I've fixed libtapp to support modern C++ standards and filed a pull request to the upstream: https://github.com/cbab/libtappp/pull/5 

But this patch have never been applied and that fork is seems to be abandoned.

So I've created my own fork: https://gitlab.com/dhyannataraj/libtappp and applied patch there...

I suggest to use my fork by default if you do TAP testing of C++ projects.

That is why I am suggesting to change links at http://testanything.org to it.